### PR TITLE
Throw Error instead of process.exit when prod-required value is not set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ module.exports = function envOr (name, or, requireInProd) {
 	const noOr = requireInProd && 'production' === env.NODE_ENV;
 	if (noOr) {
 		log.error(`Accessed environment "${name}", which was unavailable. Fallbacks are not allowed in production for this variable`);
-		return process.exit(1);
+		throw new Error(`Accessed environment "${name}", which was unavailable. Fallbacks are not allowed in production for this variable`);
 	}
 
 	if (undefined !== or) {

--- a/test/index.js
+++ b/test/index.js
@@ -164,18 +164,15 @@ describe('envOr', function () {
 				beforeEach(function () {
 					previous = process.env.NODE_ENV;
 					process.env.NODE_ENV = 'production';
-					sinon.stub(process, 'exit');
 				});
 
 				afterEach(function () {
 					process.env.NODE_ENV = previous;
-					process.exit.restore();
 				});
 
 				it('should exit the process', function () {
 					setAs(undefined);
-					get.requireInProd(or);
-					expect(process.exit).to.have.been.calledWith(1);
+					expect(get.requireInProd.bind(undefined, or)).to.throw(/Fallbacks are not allowed/);
 					expect(log.error).to.have.been.calledWithMatch('Fallbacks are not allowed');
 				});
 			});


### PR DESCRIPTION
Just using a normal `Error`, since it's really not intended to be caught anyway. Fixes #2 
