### PR TITLE
remove registry-url from Brightspace/setup-node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: Brightspace/setup-node@main
         with:
           node-version: ${{ matrix.node }}
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: npm install

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "LICENSE",
     "README.md"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "check-style": "eslint --ignore-path .gitignore .",
     "start": "node ./",


### PR DESCRIPTION
The `registry-url` input will soon be managed by Brightspace/setup-node itself.
The registry to publish packages to is now defined in `publishConfig` in `package.json`.

[HOD-4561 - Proxy Registry > Update Brightspace/setup-node](https://desire2learn.atlassian.net/browse/HOD-4561)